### PR TITLE
chore: Adds release flag to CMake configuration

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -4,6 +4,6 @@ include /usr/share/dpkg/default.mk
 %:
 	dh $@ --buildsystem=cmake
 
-EXTRA_OPTION = -DCMAKE_BUILD_TYPE=Release -Dlinyaps-box_ENABLE_CPACK=ON -Dlinyaps-box_CPM_LOCAL_PACKAGES_ONLY=ON
+EXTRA_OPTION = -DCMAKE_BUILD_TYPE=Release -Dlinyaps-box_ENABLE_CPACK=ON -Dlinyaps-box_CPM_LOCAL_PACKAGES_ONLY=ON -Dlinyaps-box_MAKE_RELEASE=ON
 override_dh_auto_configure:
 	dh_auto_configure --  ${EXTRA_OPTION}  ${DH_AUTO_ARGS}


### PR DESCRIPTION
Enhances the CMake configuration by introducing the `MAKE_RELEASE` flag to the build options. This ensures that release-specific settings are applied during the build process, improving consistency and alignment with release requirements.