### PR TITLE
chore: update patch context lines for container.cpp

### DIFF
--- a/debian/patches/0001-feat-write-cred-before-start-container-process.patch
+++ b/debian/patches/0001-feat-write-cred-before-start-container-process.patch
@@ -1,8 +1,8 @@
-diff --git a/src/linyaps_box/container.cpp b/src/linyaps_box/container.cpp
-index 9cca48d..932fc9a 100644
---- a/src/linyaps_box/container.cpp
-+++ b/src/linyaps_box/container.cpp
-@@ -1251,6 +1251,14 @@ void configure_mounts(const linyaps_box::container &container, const std::filesy
+Index: linyaps-box/src/linyaps_box/container.cpp
+===================================================================
+--- linyaps-box.orig/src/linyaps_box/container.cpp
++++ linyaps-box/src/linyaps_box/container.cpp
+@@ -1382,6 +1382,14 @@ void configure_mounts(linyaps_box::conta
          return ss.str();
      }();
  
@@ -14,6 +14,6 @@ index 9cca48d..932fc9a 100644
 +        ofs << "1";
 +    }
 +
-     execvpe(c_args[0],
+     execvpe(c_args.at(0),
              const_cast<char *const *>(c_args.data()), // NOLINT
              const_cast<char *const *>(c_env.data())); // NOLINT


### PR DESCRIPTION
Update the patch file to reflect recent source code changes in container.cpp. The function signature changed from `const linyaps_box::container &container` to `linyaps_box::container` (removing const reference), and the execvpe call changed from `c_args[0]` to `c_args.at(0)` (using bounds-checked access). These are mechanical updates to keep the patch applicable after upstream refactoring.

Influence:
1. Verify the patch applies cleanly to the current source tree
2. Test container credential writing functionality still works correctly
3. Verify container startup process completes successfully
4. Check that /proc/self/uid_map and gid_map files are written with "1" as expected
5. Ensure no regression in container process execution