### PR TITLE
build(deps): add libsystemd-dev as build dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,8 @@ Build-Depends:
  libseccomp-dev,
  nlohmann-json3-dev (>= 3.5.0) | hello,
  libgtest-dev,
- libcap-dev
+ libcap-dev,
+ libsystemd-dev
 Standards-Version: 4.1.3
 Homepage: https://www.deepin.org
 

--- a/rpm/linyaps-box.spec
+++ b/rpm/linyaps-box.spec
@@ -7,7 +7,7 @@ License:        LGPLv3
 URL:            https://github.com/linuxdeepin/%{name}
 Source0:        %{url}/archive/%{version}/linglong-box-%{version}.tar
 
-BuildRequires:  cmake gcc-c++ glib2-devel glibc-static libstdc++-static gtest-devel gmock-devel libseccomp-devel libcap-devel
+BuildRequires:  cmake gcc-c++ glib2-devel glibc-static libstdc++-static gtest-devel gmock-devel libseccomp-devel libcap-devel systemd-devel
 
 %description
 Linglong sandbox with OCI standard.


### PR DESCRIPTION
The logging subsystem uses systemd journald, so libsystemd-dev is needed for sd-journal integration.